### PR TITLE
Update -appID to -app-id mobile.md

### DIFF
--- a/started/mobile.md
+++ b/started/mobile.md
@@ -22,8 +22,8 @@ everything for you. Be sure to have a unique application identifier as it is
 unwise to change these after your first release.
 
 ```
-fyne package -os android -appID com.example.myapp -icon mobileIcon.png
-fyne package -os ios -appID com.example.myapp -icon mobileIcon.png
+fyne package -os android -app-id com.example.myapp -icon mobileIcon.png
+fyne package -os ios -app-id com.example.myapp -icon mobileIcon.png
 ```
 
 After these commands have completed (which may take some time on first
@@ -45,7 +45,7 @@ the `myapp.app` icon onto your app list.
 If you want to install on a simulator make sure to package your application using `iossimulator` vs `ios` 
 
 ```
-fyne package -os iossimulator -appID com.example.myapp -icon mobileIcon.png
+fyne package -os iossimulator -app-id com.example.myapp -icon mobileIcon.png
 ```
 
 Afterwards you can use the command line tools as follows:


### PR DESCRIPTION
Issue with Android Build Flag

When running the following command:

fyne package -os android -appID com.example.myapp -icon mobileIcon.png

The following error was encountered:

Incorrect Usage: flag provided but not defined: -appID

Solution

The correct flag for specifying the application ID is -app-id (with a hyphen instead of camel case). To resolve the issue, update the command as follows:

fyne package -os android -app-id com.example.myapp -icon mobileIcon.png fyne package -os ios -app-id com.example.myapp -icon mobileIcon.png

This will successfully build the app for Android without the flag error.